### PR TITLE
Ops: testing redirect workflow

### DIFF
--- a/.github/workflows/testing-redirect.yml
+++ b/.github/workflows/testing-redirect.yml
@@ -1,0 +1,42 @@
+name: Apply testing redirect
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  redirect-testing:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: SSH into testing server and apply Apache redirect
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.TEST_HOST }}
+          username: ${{ secrets.TEST_USERNAME }}
+          key: ${{ secrets.TEST_SSH_KEY }}
+          port: ${{ secrets.TEST_SSH_PORT }}
+          script_stop: true
+          script: |
+            set -euo pipefail
+
+            echo "==> Creating redirect config for testing.exight.in"
+            sudo bash -lc 'cat > /etc/httpd/conf.d/redirect-testing.conf <<"EOF"\n# Auto-managed by GitHub Actions: Redirect testing.exight.in to GitHub Pages\n# Applies at server context using mod_rewrite and restricts by Host header\n<IfModule mod_rewrite.c>\n  RewriteEngine On\n  RewriteCond %{HTTP_HOST} ^testing\\.exight\\.in$ [NC]\n  RewriteRule ^/(.*)$ https://rescuedragon.github.io/exight2.0/$1 [R=301,L]\n</IfModule>\nEOF'
+
+            echo "==> Checking loaded modules for mod_rewrite"
+            sudo apachectl -M | grep -i rewrite || echo "mod_rewrite not listed; continuing"
+
+            echo "==> Validate Apache configuration"
+            sudo apachectl configtest
+
+            echo "==> Reload Apache"
+            sudo systemctl reload httpd || sudo service httpd reload
+
+            echo "==> Post-check: fetch headers"
+            curl -I -L -s https://testing.exight.in | sed -n '1,20p'
+
+


### PR DESCRIPTION
Adds a manual workflow to SSH into testing server and apply an Apache 301 redirect for testing.exight.in to GitHub Pages (no DNS change required).